### PR TITLE
Update syntax based on haltman-at feedback

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -72,6 +72,8 @@ function hljsDefineSolidity(hljs) {
             'assert require revert ' +
             'sha3 sha256 ripemd160 erecover addmod mulmod ' +
             'abi ' +
+            'blockhash ' +
+            'gasleft keccak256 type ' +
             // :NOTE: not really toplevel, but advantageous to have highlighted as if reserved to
             //        avoid newcomers making mistakes due to accidental name collisions.
             'send call callcode delegatecall',

--- a/solidity.js
+++ b/solidity.js
@@ -31,10 +31,14 @@ function hljsDefineSolidity(hljs) {
             'bytes9 bytes10 bytes11 bytes12 bytes13 bytes14 bytes15 bytes16 ' +
             'bytes17 bytes18 bytes19 bytes20 bytes21 bytes22 bytes23 bytes24 ' +
             'bytes25 bytes26 bytes27 bytes28 bytes29 bytes30 bytes31 bytes32 ' +
+            'fixed ufixed ' +
             'enum struct mapping address ' +
+            'payable ' +
+            'calldata ' +
+            'constructor ' +
 
             'new delete ' +
-            'if else for while continue break return throw assert require revert ' +
+            'if else for while continue break return throw ' +
 
             'function modifier event ' +
             'constant anonymous indexed ' +
@@ -43,11 +47,21 @@ function hljsDefineSolidity(hljs) {
 
             'import using ' +
             'contract interface library ' +
-            'assembly',
+            'emit ' +
+            'pragma solidity experimental ' +
+            'staticcall ' +
+            'transfer ' +
+            'pop name creationCode runtimeCode ' +
+            'assembly ' +
+            'copy virtual override abstract fallback ' +
+            // reserved but currently unused
+            'abstract after alias apply auto case catch copyof default define final immutable ' +
+            'implements in inline let macro match mutable null of override partial promise reference ' +
+            'relocatable sealed sizeof static supports switch try typedef typeof unchecked',
         literal:
             'true false ' +
             'wei szabo finney ether ' +
-            'second seconds minute minutes hour hours day days week weeks year years',
+            'seconds minutes hours days weeks years',
         built_in:
             'self ' +   // :NOTE: not a real keyword, but a convention used in storage manipulation libraries
             'this super selfdestruct ' +
@@ -55,7 +69,9 @@ function hljsDefineSolidity(hljs) {
             'msg ' +
             'block ' +
             'tx ' +
+            'assert require revert ' +
             'sha3 sha256 ripemd160 erecover addmod mulmod ' +
+            'abi ' +
             // :NOTE: not really toplevel, but advantageous to have highlighted as if reserved to
             //        avoid newcomers making mistakes due to accidental name collisions.
             'send call callcode delegatecall',
@@ -136,9 +152,10 @@ function hljsDefineSolidity(hljs) {
                 illegal: /\[|%/,
             },
             // built-in members
-            makeBuiltinProps('msg', 'data sender sig'),
-            makeBuiltinProps('block', 'blockhash coinbase difficulty gaslimit number timestamp '),
+            makeBuiltinProps('msg', 'data sender sig value gas'),
+            makeBuiltinProps('block', 'blockhash coinbase difficulty gaslimit number timestamp'),
             makeBuiltinProps('tx', 'gasprice origin'),
+            makeBuiltinProps('abi', 'decode encode encodePacked encodeWithSelector encodeWithSignature'),
             SOL_RESERVED_MEMBERS,
             { // contracts & libraries & interfaces
                 className: 'class',


### PR DESCRIPTION
**Removed literals** 
second, minute, hour, day, week, year

**Added keywords:**
fixed, ufixed (as a start, have not added fixedMxN and ufixedMxN for appropriate values of M and N)
payable
calldata
emit 
pragma 
solidity
experimental
constructor
staticcall
transfer
pop 
name 
creationCode
runtimeCode

**Added keywords (reserved words):**
abstract, after, alias, apply, auto, case, catch, copyof, default, define, final, immutable, implements, in, inline, let, macro, match, mutable, null, of, override, partial, promise, reference, relocatable, sealed, sizeof, static, supports, switch, try, typedef, typeof, unchecked

**Moved to builtins:**
assert, revert, require
send, call, callcode, delegatecall

**Added to builtins**
blockhash gasleft keccak256 type

**Added to generated builtins:**
abi.decode, abi.encode, abi.encodePacked, abi.encodeWithSelector, abi.encodeWithSignature 
msg.gas

**Not done**
Left self as is.
Hex strings of the form hex"deadbeef..." or hex'deadbeef...'; 
have not added fixedMxN and ufixedMxN for appropriate values of M and N
suicide