### PR TITLE
Update for 0.5.x, add other missing things, other various fixes

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -175,7 +175,7 @@ function hljsDefineSolidity(hljs) {
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
-            built_in: 'gas value send transfer call callcode delegatecall staticcall balance length push pop name creationCode runtimeCode',
+            built_in: 'gas value selector send transfer call callcode delegatecall staticcall balance length push pop name creationCode runtimeCode',
         },
         relevance: 2,
     };

--- a/solidity.js
+++ b/solidity.js
@@ -116,7 +116,7 @@ function hljsDefineSolidity(hljs) {
     //covers the special slot/offset notation in assembly
     var SOL_ASSEMBLY_MEMBERS = {
         begin: /_/,
-        end: /[^A-Za-z0-9$]/,
+        end: /[^A-Za-z0-9$.]/,
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
@@ -166,6 +166,8 @@ function hljsDefineSolidity(hljs) {
 
     //NOTE: including "*" as a "lexeme" because we use it as a "keyword" below
     var SOL_LEXEMES_RE = /[A-Za-z_$][A-Za-z_$0-9]*|\*/;
+    //in assembly, identifiers can contain periods (but may not start with them)
+    var SOL_ASSEMBLY_LEXEMES_RE = /[A-Za-z_$][A-Za-z_$0-9.]*/;
 
     var SOL_RESERVED_MEMBERS = {
         begin: /\.\s*/,  // match any property access up to start of prop
@@ -295,12 +297,12 @@ function hljsDefineSolidity(hljs) {
             { //assembly block
                 begin: /assembly\s*{/, end: '}',
                 keywords: SOL_ASSEMBLY_KEYWORDS,
-                lexemes: SOL_LEXEMES_RE,
+                lexemes: SOL_ASSEMBLY_LEXEMES_RE,
                 contains: [
                     hljs.APOS_STRING_MODE,
                     hljs.QUOTE_STRING_MODE,
                     HEX_APOS_STRING_MODE,
-                    HEX_QUOTE_SRING_MODE,
+                    HEX_QUOTE_STRING_MODE,
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE,
                     SOL_NUMBER,
@@ -308,12 +310,12 @@ function hljsDefineSolidity(hljs) {
                     { //block within assembly
                         begin: '{', end: '}',
                         keywords: SOL_ASSEMBLY_KEYWORDS,
-                        lexemes: SOL_LEXEMES_RE,
+                        lexemes: SOL_ASSEMBLY_LEXEMES_RE,
                         contains: [
                             hljs.APOS_STRING_MODE,
                             hljs.QUOTE_STRING_MODE,
                             HEX_APOS_STRING_MODE,
-                            HEX_QUOTE_SRING_MODE,
+                            HEX_QUOTE_STRING_MODE,
                             hljs.C_LINE_COMMENT_MODE,
                             hljs.C_BLOCK_COMMENT_MODE,
                             SOL_NUMBER,

--- a/solidity.js
+++ b/solidity.js
@@ -278,6 +278,7 @@ function hljsDefineSolidity(hljs) {
             { //assembly block
                 begin: /assembly\s*{/, end: '}',
                 keywords: SOL_ASSEMBLY_KEYWORDS,
+                lexemes: SOL_LEXEMES_RE,
                 contains: [
                     hljs.APOS_STRING_MODE,
                     hljs.QUOTE_STRING_MODE,
@@ -290,6 +291,7 @@ function hljsDefineSolidity(hljs) {
                     { //block within assembly
                         begin: '{', end: '}',
                         keywords: SOL_ASSEMBLY_KEYWORDS,
+                        lexemes: SOL_LEXEMES_RE,
                         contains: [
                             hljs.APOS_STRING_MODE,
                             hljs.QUOTE_STRING_MODE,

--- a/solidity.js
+++ b/solidity.js
@@ -294,22 +294,15 @@ function hljsDefineSolidity(hljs) {
                     hljs.C_BLOCK_COMMENT_MODE
                 ]
             },
-            { //assembly block
-                begin: /assembly/, end: '}',
-		excludeBegin: true,
-                keywords: SOL_ASSEMBLY_KEYWORDS,
-                lexemes: SOL_ASSEMBLY_LEXEMES_RE,
+            { //assembly section
+                beginKeywords: 'assembly',
+                end: /\b\B/, //unsatisfiable regex; ended by endsParent instead
                 contains: [
-                    hljs.APOS_STRING_MODE,
-                    hljs.QUOTE_STRING_MODE,
-                    HEX_APOS_STRING_MODE,
-                    HEX_QUOTE_STRING_MODE,
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE,
-                    SOL_NUMBER,
-                    SOL_ASSEMBLY_MEMBERS,
-                    { //block within assembly
+                    { //the actual *block* in the assembly section
                         begin: '{', end: '}',
+                        endsParent: true,
                         keywords: SOL_ASSEMBLY_KEYWORDS,
                         lexemes: SOL_ASSEMBLY_LEXEMES_RE,
                         contains: [
@@ -321,7 +314,22 @@ function hljsDefineSolidity(hljs) {
                             hljs.C_BLOCK_COMMENT_MODE,
                             SOL_NUMBER,
                             SOL_ASSEMBLY_MEMBERS,
-                            'self'
+                            { //block within assembly; note the lack of endsParent
+                                begin: '{', end: '}',
+                                keywords: SOL_ASSEMBLY_KEYWORDS,
+                                lexemes: SOL_ASSEMBLY_LEXEMES_RE,
+                                contains: [
+                                    hljs.APOS_STRING_MODE,
+                                    hljs.QUOTE_STRING_MODE,
+                                    HEX_APOS_STRING_MODE,
+                                    HEX_QUOTE_STRING_MODE,
+                                    hljs.C_LINE_COMMENT_MODE,
+                                    hljs.C_BLOCK_COMMENT_MODE,
+                                    SOL_NUMBER,
+                                    SOL_ASSEMBLY_MEMBERS,
+                                    'self'
+                                ]
+                            }
                         ]
                     }
                 ]

--- a/solidity.js
+++ b/solidity.js
@@ -3,9 +3,6 @@
  *
  * @see https://github.com/isagalaev/highlight.js
  *
- * :TODO:
- * - assembly block keywords
- *
  * @package: highlightjs-solidity
  * @author:  Sam Pospischil <sam@changegiving.com>
  * @since:   2016-07-01
@@ -86,28 +83,30 @@ function hljsDefineSolidity(hljs) {
             'sha3 sha256 keccak256 ripemd160 ecrecover addmod mulmod ' +
             // :NOTE: not really toplevel, but advantageous to have highlighted as if reserved to
             //        avoid newcomers making mistakes due to accidental name collisions.
-            'send transfer call callcode delegatecall staticcall ',
+            'send transfer call callcode delegatecall staticcall '
     };
 
     var SOL_ASSEMBLY_KEYWORDS = {
         keyword:
             'assembly ' +
             'let ' +
-            'if switch case default for',
+            'if switch case default for ' +
+            //NOTE: I'm counting most opcodes as builtins, but the following ones I'm
+            //treating as keywords because they alter control flow or halt execution
+            'jump jumpi ' +
+            'stop return revert selfdestruct invalid',
         built_in:
             //NOTE that push1 through push32, as well as jumpdest, are not included
-            'stop ' +
             'add sub mul div sdiv mod smod exp not lt gt slt sgt eq iszero ' +
             'and or xor byte shl shr sar ' +
             'addmod mulmod signextend keccak256 ' +
-            'jump jumpi pc pop ' +
+            'pc pop ' +
             'dup1 dup2 dup3 dup4 dup5 dup6 dup7 dup8 dup9 dup10 dup11 dup12 dup13 dup14 dup15 dup16 ' +
             'swap1 swap2 swap3 swap4 swap5 swap6 swap7 swap8 swap9 swap10 swap11 swap12 swap13 swap14 swap15 swap16 ' +
-            'mload mstore mstore8 sload sstore msize
+            'mload mstore mstore8 sload sstore msize ' +
             'gas address balance caller callvalue ' +
             'calldataload calldatasize calldatacopy codesize codecopy extcodesize extcodecopy returndatasize returndatacopy extcodehash ' +
             'create create2 call callcode delegatecall staticcall ' +
-            'return revert selfdestruct invalid ' +
             'log0 log1 log2 log3 log4 ' +
             'origin gasprice blockhash coinbase timestamp number difficulty gaslimit'
     };
@@ -115,7 +114,7 @@ function hljsDefineSolidity(hljs) {
     //covers the special slot/offset notation in assembly
     var SOL_ASSEMBLY_MEMBERS = {
         begin: /_/,
-        end: /[^A-Za-z0-9$_]/,
+        end: /[^A-Za-z0-9$]/,
         excludeBegin: true,
         excludeEnd: true,
         keywords: {

--- a/solidity.js
+++ b/solidity.js
@@ -295,7 +295,7 @@ function hljsDefineSolidity(hljs) {
                 ]
             },
             { //assembly block
-                begin: /assembly\s*{/, end: '}',
+                begin: /assembly/, end: '}',
                 keywords: SOL_ASSEMBLY_KEYWORDS,
                 lexemes: SOL_ASSEMBLY_LEXEMES_RE,
                 contains: [

--- a/solidity.js
+++ b/solidity.js
@@ -13,7 +13,7 @@ var module = module ? module : {};     // shim for browser use
 function hljsDefineSolidity(hljs) {
 
     //first: let's set up all parameterized types (bytes, int, uint, fixed, ufixed)
-    //NOTE: I'm *not* including the unparameterized versions here, those are included
+    //NOTE: unparameterized versions are *not* included here, those are included
     //manually
     var byteSizes = [];
     for(var i = 0; i < 32; i++) {
@@ -58,7 +58,7 @@ function hljsDefineSolidity(hljs) {
 
             'new delete ' +
             'if else for while continue break return throw emit ' +
-            //NOTE: doesn't always act as a keyword, but I think it's fine to include
+            //NOTE: doesn't always act as a keyword, but seems fine to include
             '_ ' +
 
             'function modifier event constructor ' +
@@ -93,7 +93,7 @@ function hljsDefineSolidity(hljs) {
             'assembly ' +
             'let ' +
             'if switch case default for ' +
-            //NOTE: I'm counting most opcodes as builtins, but the following ones I'm
+            //NOTE: We're counting most opcodes as builtins, but the following ones we're
             //treating as keywords because they alter control flow or halt execution
             'jump jumpi ' +
             'stop return revert selfdestruct invalid',
@@ -129,8 +129,7 @@ function hljsDefineSolidity(hljs) {
     //1. no octal literals (leading zeroes disallowed)
     //2. underscores (1 apiece) are allowed between consecutive digits
     //(including hex digits)
-    //also, I've replaced all instances of \b (word boundary)
-    //with (?<![A-Za-z0-9_$])
+    //also, all instances of \b (word boundary) have been replaced with (?<![A-Za-z0-9_$])
     var SOL_NUMBER_RE = /-?((?<![A-Za-z0-9_$])0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|((?<![A-Za-z0-9_$])[1-9](_?\d)*(\.((\d_?)*\d)?)?|\.\d(_?\d)*)([eE][-+]?\d(_?\d)*)?|(?<![A-Za-z0-9_$])0)/;
 
     var SOL_NUMBER = {

--- a/solidity.js
+++ b/solidity.js
@@ -4,8 +4,6 @@
  * @see https://github.com/isagalaev/highlight.js
  *
  * :TODO:
- * - fixed point numbers
- * - `_` inside modifiers
  * - assembly block keywords
  *
  * @package: highlightjs-solidity
@@ -16,58 +14,90 @@
 var module = module ? module : {};     // shim for browser use
 
 function hljsDefineSolidity(hljs) {
+
+    //first: let's set up all parameterized types (bytes, int, uint, fixed, ufixed)
+    //NOTE: I'm *not* including the unparameterized versions here, those are included
+    //manually
+    var byteSizes = [];
+    for(var i = 0; i < 32; i++) {
+        byteSizes[i] = i+1;
+    }
+    var numSizes = byteSizes.map(function(bytes) { return bytes * 8 } );
+    for(i = 0; i <= 80; i++) {
+        precisions[i] = i;
+    }
+
+    var bytesTypes = byteSizes.map(function(size) { return 'bytes' + size });
+    var bytesTypesString = bytesTypes.join(' ') + ' ';
+
+    var uintTypes = numSizes.map(function(size) { return 'uint' + size });
+    var uintTypesString = uintTypes.join(' ') + ' ';
+
+    var intTypes = numSizes.map(function(size) { return 'int' + size });
+    var intTypesString = intTypes.join(' ') + ' ';
+
+    var sizePrecisionPairs = [].concat.apply([],
+        numSizes.map(function(size) {
+            return precisions.map(function(precision) {
+                return size + 'x' + precision;
+            })
+        })
+    );
+
+    var fixedTypes = sizePrecisionPairs.map(function(pair) { return 'fixed' + pair });
+    var fixedTypesString = fixedTypes.join(' ') + ' ';
+
+    var ufixedTypes = sizePrecisionPairs.map(function(pair) { return 'ufixed' + pair });
+    var ufixedTypesString = ufixedTypes.join(' ') + ' ';
+
     var SOL_KEYWORDS = {
         keyword:
             'var bool string ' +
-            'int uint int8 uint8 int16 uint16 int24 uint24 int32 uint32 ' +
-            'int40 uint40 int48 uint48 int56 uint56 int64 uint64 ' +
-            'int72 uint72 int80 uint80 int88 uint88 int96 uint96 ' +
-            'int104 uint104 int112 uint112 int120 uint120 int128 uint128 ' +
-            'int136 uint136 int144 uint144 int152 uint152 int160 uint160 ' +
-            'int168 uint168 int176 uint176 int184 uint184 int192 uint192 ' +
-            'int200 uint200 int208 uint208 int216 uint216 int224 uint224 ' +
-            'int232 uint232 int240 uint240 int248 uint248 int256 uint256 ' +
-            'byte bytes bytes1 bytes2 bytes3 bytes4 bytes5 bytes6 bytes7 bytes8 ' +
-            'bytes9 bytes10 bytes11 bytes12 bytes13 bytes14 bytes15 bytes16 ' +
-            'bytes17 bytes18 bytes19 bytes20 bytes21 bytes22 bytes23 bytes24 ' +
-            'bytes25 bytes26 bytes27 bytes28 bytes29 bytes30 bytes31 bytes32 ' +
+            'int uint ' + intTypesString + uintTypesString +
+            'byte bytes ' + bytesTypesString +
+            'fixed ufixed ' + fixedTypesString + ufixedTypesString +
             'enum struct mapping address ' +
 
             'new delete ' +
-            'if else for while continue break return throw assert require revert ' +
+            'if else for while continue break return throw emit ' +
+            //NOTE: doesn't always act as a keyword, but I think it's fine to include
+            '_ ' +
 
-            'function modifier event ' +
+            'function modifier event constructor ' +
             'constant anonymous indexed ' +
-            'storage memory ' +
-            'external public internal pure view private returns ' +
+            'storage memory calldata ' +
+            'external public internal payable pure view private returns ' +
 
-            'import using ' +
+            'import using pragma ' +
             'contract interface library ' +
             'assembly',
         literal:
             'true false ' +
             'wei szabo finney ether ' +
-            'second seconds minute minutes hour hours day days week weeks year years',
+            'seconds minutes hours days weeks years',
         built_in:
             'self ' +   // :NOTE: not a real keyword, but a convention used in storage manipulation libraries
-            'this super selfdestruct ' +
+            'this super selfdestruct suicide ' +
             'now ' +
-            'msg ' +
-            'block ' +
-            'tx ' +
-            'sha3 sha256 ripemd160 erecover addmod mulmod ' +
+            'msg block tx abi ' +
+            'type '
+            'blockhash gasleft ' +
+            'assert revert require ' +
+            'sha3 sha256 keccak256 ripemd160 ecrecover addmod mulmod ' +
             // :NOTE: not really toplevel, but advantageous to have highlighted as if reserved to
             //        avoid newcomers making mistakes due to accidental name collisions.
-            'send call callcode delegatecall',
+            'send transfer call callcode delegatecall staticcall ',
     };
+
+    //like a C number, except:
+    //1. no octal literals (leading zeroes disallowed)
+    //2. underscores (1 apiece) are allowed between consecutive digits
+    //(including hex digits)
+    var SOL_NUMBER_RE = /-?(\b0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|(\b[1-9](_?\d)*(\.((\d_?)*\d)?)?|\.\d(_?\d)*)([eE][-+]?\d(_?\d)*)?)/;
 
     var SOL_NUMBER = {
         className: 'number',
-        variants: [
-            { begin: '\\b(0[bB][01]+)' },
-            { begin: '\\b(0[oO][0-7]+)' },
-            { begin: hljs.C_NUMBER_RE },
-        ],
+        begin: SOL_NUMBER_RE,
         relevance: 0,
     };
 
@@ -86,13 +116,22 @@ function hljsDefineSolidity(hljs) {
         ],
     };
 
+    var HEX_APOS_STRING_MODE = {
+      className: 'string',
+      begin: /hex'[0-9a-fA-F]'/,
+    };
+    var HEX_QUOTE_STRING_MODE = {
+      className: 'string',
+      begin: /hex"[0-9a-fA-F]"/,
+    };
+
     var SOL_RESERVED_MEMBERS = {
         begin: /\.\s*/,  // match any property access up to start of prop
         end: /[^A-Za-z0-9$_\.]/,
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
-            built_in: 'gas value send call callcode delegatecall balance length push',
+            built_in: 'gas value send transfer call callcode delegatecall staticcall balance length push pop name creationCode runtimeCode',
         },
         relevance: 2,
     };
@@ -120,6 +159,8 @@ function hljsDefineSolidity(hljs) {
             // basic literal definitions
             hljs.APOS_STRING_MODE,
             hljs.QUOTE_STRING_MODE,
+            HEX_APOS_STRING_MODE,
+            HEX_QUOTE_SRING_MODE,
             hljs.C_LINE_COMMENT_MODE,
             hljs.C_BLOCK_COMMENT_MODE,
             SOL_NUMBER,
@@ -132,13 +173,16 @@ function hljsDefineSolidity(hljs) {
                         keywords: SOL_KEYWORDS,
                     }),
                     SOL_FUNC_PARAMS,
+                    hljs.C_LINE_COMMENT_MODE,
+                    hljs.C_BLOCK_COMMENT_MODE,
                 ],
                 illegal: /\[|%/,
             },
             // built-in members
-            makeBuiltinProps('msg', 'data sender sig'),
+            makeBuiltinProps('msg', 'gas value data sender sig'),
             makeBuiltinProps('block', 'blockhash coinbase difficulty gaslimit number timestamp '),
             makeBuiltinProps('tx', 'gasprice origin'),
+            makeBuiltinProps('abi', 'decode encode encodePacked encodeWithSelector encodeWithSignature'),
             SOL_RESERVED_MEMBERS,
             { // contracts & libraries & interfaces
                 className: 'class',
@@ -148,14 +192,39 @@ function hljsDefineSolidity(hljs) {
                     { beginKeywords: 'is' },
                     hljs.UNDERSCORE_TITLE_MODE,
                     SOL_FUNC_PARAMS,
+                    hljs.C_LINE_COMMENT_MODE,
+                    hljs.C_BLOCK_COMMENT_MODE,
                 ],
             },
             { // imports
-                beginKeywords: 'import', end: '[;$]',
+                beginKeywords: 'import', end: ';|$',
                 keywords: 'import * from as',
                 contains: [
                     hljs.APOS_STRING_MODE,
                     hljs.QUOTE_STRING_MODE,
+                    HEX_APOS_STRING_MODE,
+                    HEX_QUOTE_SRING_MODE,
+                    hljs.C_LINE_COMMENT_MODE,
+                    hljs.C_BLOCK_COMMENT_MODE,
+                ],
+            },
+            { // using
+                beginKeywords: 'import', end: ';|$',
+                keywords: 'using * for',
+                contains: [
+                    hljs.C_LINE_COMMENT_MODE,
+                    hljs.C_BLOCK_COMMENT_MODE,
+                ],
+            },
+            { // pragmas
+                beginKeywords: 'pragma', end: ';|$',
+                keywords: {
+                    keyword: 'pragma solidity experimental',
+                    built_in: 'ABIEncoderV2 SMTChecker'
+                },
+                contains: [
+                    hljs.C_LINE_COMMENT_MODE,
+                    hljs.C_BLOCK_COMMENT_MODE,
                 ],
             },
         ],

--- a/solidity.js
+++ b/solidity.js
@@ -259,7 +259,7 @@ function hljsDefineSolidity(hljs) {
                 ]
             },
             { // imports
-                beginKeywords: 'import', end: ';|$',
+                beginKeywords: 'import', end: ';',
                 lexemes: SOL_LEXEMES_RE,
                 keywords: 'import * from as',
                 contains: [
@@ -273,7 +273,7 @@ function hljsDefineSolidity(hljs) {
                 ]
             },
             { // using
-                beginKeywords: 'using', end: ';|$',
+                beginKeywords: 'using', end: ';',
                 lexemes: SOL_LEXEMES_RE,
                 keywords: 'using * for',
                 contains: [
@@ -283,7 +283,7 @@ function hljsDefineSolidity(hljs) {
                 ]
             },
             { // pragmas
-                beginKeywords: 'pragma', end: ';|$',
+                beginKeywords: 'pragma', end: ';',
                 lexemes: SOL_LEXEMES_RE,
                 keywords: {
                     keyword: 'pragma solidity experimental',
@@ -296,6 +296,7 @@ function hljsDefineSolidity(hljs) {
             },
             { //assembly block
                 begin: /assembly/, end: '}',
+		excludeBegin: true,
                 keywords: SOL_ASSEMBLY_KEYWORDS,
                 lexemes: SOL_ASSEMBLY_LEXEMES_RE,
                 contains: [

--- a/solidity.js
+++ b/solidity.js
@@ -89,6 +89,41 @@ function hljsDefineSolidity(hljs) {
             'send transfer call callcode delegatecall staticcall ',
     };
 
+    var SOL_ASSEMBLY_KEYWORDS = {
+        keyword:
+            'assembly ' +
+            'let ' +
+            'if switch case default for',
+        built_in:
+            //NOTE that push1 through push32, as well as jumpdest, are not included
+            'stop ' +
+            'add sub mul div sdiv mod smod exp not lt gt slt sgt eq iszero ' +
+            'and or xor byte shl shr sar ' +
+            'addmod mulmod signextend keccak256 ' +
+            'jump jumpi pc pop ' +
+            'dup1 dup2 dup3 dup4 dup5 dup6 dup7 dup8 dup9 dup10 dup11 dup12 dup13 dup14 dup15 dup16 ' +
+            'swap1 swap2 swap3 swap4 swap5 swap6 swap7 swap8 swap9 swap10 swap11 swap12 swap13 swap14 swap15 swap16 ' +
+            'mload mstore mstore8 sload sstore msize
+            'gas address balance caller callvalue ' +
+            'calldataload calldatasize calldatacopy codesize codecopy extcodesize extcodecopy returndatasize returndatacopy extcodehash ' +
+            'create create2 call callcode delegatecall staticcall ' +
+            'return revert selfdestruct invalid ' +
+            'log0 log1 log2 log3 log4 ' +
+            'origin gasprice blockhash coinbase timestamp number difficulty gaslimit'
+    };
+
+    //covers the special slot/offset notation in assembly
+    var SOL_ASSEMBLY_MEMBERS = {
+        begin: /_/,
+        end: /[^A-Za-z0-9$_]/,
+        excludeBegin: true,
+        excludeEnd: true,
+        keywords: {
+            built_in: 'slot offset'
+        },
+        relevance: 2,
+    };
+
     //like a C number, except:
     //1. no octal literals (leading zeroes disallowed)
     //2. underscores (1 apiece) are allowed between consecutive digits
@@ -194,7 +229,7 @@ function hljsDefineSolidity(hljs) {
                     SOL_FUNC_PARAMS,
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE,
-                ],
+                ]
             },
             { // imports
                 beginKeywords: 'import', end: ';|$',
@@ -206,7 +241,7 @@ function hljsDefineSolidity(hljs) {
                     HEX_QUOTE_SRING_MODE,
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE,
-                ],
+                ]
             },
             { // using
                 beginKeywords: 'import', end: ';|$',
@@ -214,7 +249,7 @@ function hljsDefineSolidity(hljs) {
                 contains: [
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE,
-                ],
+                ]
             },
             { // pragmas
                 beginKeywords: 'pragma', end: ';|$',
@@ -225,8 +260,37 @@ function hljsDefineSolidity(hljs) {
                 contains: [
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE,
-                ],
+                ]
             },
+            { //assembly block
+                begin: /assembly\s*{/, end: '}',
+                keywords: SOL_ASSEMBLY_KEYWORDS,
+                contains: [
+                    hljs.APOS_STRING_MODE,
+                    hljs.QUOTE_STRING_MODE,
+                    HEX_APOS_STRING_MODE,
+                    HEX_QUOTE_SRING_MODE,
+                    hljs.C_LINE_COMMENT_MODE,
+                    hljs.C_BLOCK_COMMENT_MODE,
+                    SOL_NUMBER,
+                    SOL_ASSEMBLY_MEMBERS,
+                    { //block within assembly
+                        begin: '{', end: '}',
+                        keywords: SOL_ASSEMBLY_KEYWORDS,
+                        contains: [
+                            hljs.APOS_STRING_MODE,
+                            hljs.QUOTE_STRING_MODE,
+                            HEX_APOS_STRING_MODE,
+                            HEX_QUOTE_SRING_MODE,
+                            hljs.C_LINE_COMMENT_MODE,
+                            hljs.C_BLOCK_COMMENT_MODE,
+                            SOL_NUMBER,
+                            SOL_ASSEMBLY_MEMBERS,
+                            'self'
+                        ]
+                    }
+                ]
+            }
         ],
         illegal: /#/,
     };


### PR DESCRIPTION
This pull request attempts to address the issues I pointed out in #2.  I know @abcoathup has a parallel one (#4) to also do that, but I had some problems with that one and I also finally had time to sit down and do this myself.  Warning: I haven't really tested this and am not entirely certain I'm using highlight.js correctly.  I would appreciate review by someone who knows the library better.

So, changes made here:

1. Singular time literals have been removed.
2. Fixed-point types have been added!  Obviously I had to autogenerate these.  (Although now that I think about it, maybe these should have been a separate mode?  Oh well.)  Apologies for the old-style Javascript, but everything else here seems to be written in old-style Javascript, so I decided to stick to that, since I don't know just what versions of Node (or whatever) you support.  Please let me know if my code was still not old-style enough. :)
3. Similarly I moved other parameterized types to being similarly autogenerated.
4. Missing keywords have been added: `payable`, `calldata`, `emit`, `constructor`, `pragma`.
5. Missing builtins have been added: `blockhash`, `abi`, `gasleft`, `keccak256`, `type`, `suicide`.
6. Fixed the builtin `ecrecover`, which had been misspelled as `erecover`.
7. Added the builtin members for `abi`, as well as the generic builtin members `transfer`, `staticcall`, `pop`, `name`, `runtimeCode`, and `genericCode`
8. I also added `transfer` and `staticcall` as top-level builtins, even though they're not, for consistency with the existing code.
9. I also added `gas` and `value` as members of `msg`, even though this is unnecessary, just for completeness.
10. Moved `assert`, `revert`, and `require` from keywords section to builtins section.
11. I added `_` as a keyword.  I realize it doesn't always act as a keyword, but, I think it's fine.  It's much easier than making it work only when it should.  Again, if you think it's a problem, feel free to remove it.
12. Just as there was a mode for import declarations, I added similar modes for using declarations and pragmas.  I included the different `experimental` pragmas as builtins; hopefully that's appropriate?  Obviously feel free to change this.
13. I changed the end for the `import` mode from `[;$]` to `;|$`, since I'm assuming it was supposed to end at the end of a line, not on a dollar sign.
14. I added modes for hex strings and included those where strings are included.
15. I also added the comment modes as submodes of more of the existing modes, since comments can go basically anywhere.
16. I reworked the numbers mode; I ended up having to write a custom regex for this one (I think I got it right).  I removed octal and binary literals (I can't find anything to indicate Solidity ever had these? Am I mistaken?) and added a custom regex for Solidity numeric literals based on the provided regex for C numeric literals.  (Unlike in C, numeric literals are forbidden to start with a 0, and, more annoyingly, between any two consecutive digits (including hex digits) it is legal to place a single underscore.)

Changes considered but *not* made here:
1. I didn't de-highlight `self`, since that was a deliberate design choice.
2. Similarly, I left `call`, `send`, etc., as top-level builtins, even though they're not, since that was a deliberate design choice.  (I'd still suggest changing this one, though!)
3. I didn't add any of the assembly stuff.  Ideally I'd do that in a separate mode, but being new to highlight.js I didn't feel comfortable taking on something of that complexity.  I mean, the mode would be block-delimited, but you'd have to make sure that `}`s that end sub-blocks didn't end it, which would mean you'd have to create a mode for blocks, right?  I didn't really want to deal with that, so I chose to just leave this alone for now.  Perhaps I'll tackle this later.
4. Obviously I didn't add any 0.6.0 stuff, way too early for that.
5. Finally, I didn't add the reserved-but-unused words.  These don't actually matter for my use case, but I worried that adding them would be misleading.  Possibly they could be added as illegal -- since they are indeed illegal -- but, that also seems worrisome to me, because ideally I'd like to *highlight* them as mistakes, not stop parsing when we encounter one.  Unfortunately hightlight.js doesn't seem to support highlighting-as-illegal.  So, I just left these out.

Anyway I think that covers it.  Thanks for maintaining this!  And let me know if I'm on the right track with the block stuff, since ideally I'd like to get assembly highlighting working too.