### PR TITLE
Add is keyword; use meta class for pragmas

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -67,7 +67,7 @@ function hljsDefineSolidity(hljs) {
             'external public internal payable pure view private returns ' +
 
             'import using pragma ' +
-            'contract interface library ' +
+            'contract interface library is ' +
             'assembly',
         literal:
             'true false ' +
@@ -282,6 +282,7 @@ function hljsDefineSolidity(hljs) {
                 ]
             },
             { // pragmas
+                className: 'meta',
                 beginKeywords: 'pragma', end: ';',
                 lexemes: SOL_LEXEMES_RE,
                 keywords: {
@@ -290,7 +291,9 @@ function hljsDefineSolidity(hljs) {
                 },
                 contains: [
                     hljs.C_LINE_COMMENT_MODE,
-                    hljs.C_BLOCK_COMMENT_MODE
+                    hljs.C_BLOCK_COMMENT_MODE,
+                    hljs.inherit(hljs.APOS_STRING_MODE, { className: 'meta-string' }),
+                    hljs.inherit(hljs.QUOTE_STRING_MODE, { className: 'meta-string' })
                 ]
             },
             { //assembly section


### PR DESCRIPTION
This PR just has some really minor fixes.  Originally I had intended to use it to make a fix to string escapes, but it turns out I misunderstood how those work and actually those are completely fine, nothing needs fixing there.  So I just fixed some other stuff I noticed in the meantime.

Anyway, the PR does the following three things:

1. Adds `is` to the list of keywords.  We all missed this, it seems.  (It was in the section about contract titles, but I figured it should be in the main list of keywords too.)

2. Restyles pragmas as `meta`.

3. Adds strings to pragmas (as in `pragma experimental "v0.5.0"`, back when that was a thing) and styles them as `meta-string`.

Ideally the pragma keywords would be styled as `meta-keyword`, but, I didn't see any convenient way to do that and it didn't seem particularly important, so I left it out.

Thanks again, hoping you agree these are good changes! :)