### PR TITLE
Add selfbalance & chainid opcodes

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -106,11 +106,11 @@ function hljsDefineSolidity(hljs) {
             'dup1 dup2 dup3 dup4 dup5 dup6 dup7 dup8 dup9 dup10 dup11 dup12 dup13 dup14 dup15 dup16 ' +
             'swap1 swap2 swap3 swap4 swap5 swap6 swap7 swap8 swap9 swap10 swap11 swap12 swap13 swap14 swap15 swap16 ' +
             'mload mstore mstore8 sload sstore msize ' +
-            'gas address balance caller callvalue ' +
+            'gas address balance selfbalance caller callvalue ' +
             'calldataload calldatasize calldatacopy codesize codecopy extcodesize extcodecopy returndatasize returndatacopy extcodehash ' +
             'create create2 call callcode delegatecall staticcall ' +
             'log0 log1 log2 log3 log4 ' +
-            'origin gasprice blockhash coinbase timestamp number difficulty gaslimit'
+            'chainid origin gasprice blockhash coinbase timestamp number difficulty gaslimit'
     };
 
     //covers the special slot/offset notation in assembly


### PR DESCRIPTION
Solidity 0.5.12 was recently released, and it adds support for the new Istanbul opcodes `selfbalance` and `chainid` in the assembler.  So, I added them here to stay up to date.