### PR TITLE
Add from and as keywords to main keyword list

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -66,7 +66,7 @@ function hljsDefineSolidity(hljs) {
             'storage memory calldata ' +
             'external public internal payable pure view private returns ' +
 
-            'import using pragma ' +
+            'import from as using pragma ' +
             'contract interface library is ' +
             'assembly',
         literal:


### PR DESCRIPTION
This PR just quickly adds `from` and `as` to the main list of keywords.  This isn't really strictly necessary, since they're already listed in the keywords for the `import` environment, but I thought it would be good to include them for completeness/consistency.