### PR TITLE
Replace negative-lookbehind regexp with string for Firefox

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -139,8 +139,10 @@ function hljsDefineSolidity(hljs) {
     //2. underscores (1 apiece) are allowed between consecutive digits
     //(including hex digits)
     //also, all instances of \b (word boundary) have been replaced with (?<!\$)\b
+    //NOTE: we use string rather than regexp in the case where negative lookbehind
+    //is allowed to avoid Firefox parse errors; sorry about the resulting double backslashes!
     if (isNegativeLookbehindAvailable()) {
-        var SOL_NUMBER_RE = /-?((?<!\$)\b0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|((?<!\$)\b[1-9](_?\d)*(\.((\d_?)*\d)?)?|\.\d(_?\d)*)([eE][-+]?\d(_?\d)*)?|(?<!\$)\b0)/;
+        var SOL_NUMBER_RE = '-?((?<!\\$)\\b0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|((?<!\\$)\\b[1-9](_?\\d)*(\\.((\\d_?)*\\d)?)?|\\.\\d(_?\\d)*)([eE][-+]?\\d(_?\\d)*)?|(?<!\\$)\\b0)';
     } else {
         var SOL_NUMBER_RE = /-?(\b0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|(\b[1-9](_?\d)*(\.((\d_?)*\d)?)?|\.\d(_?\d)*)([eE][-+]?\d(_?\d)*)?|\b0)/;
     }


### PR DESCRIPTION
This PR is intended to re-fix issue #9.  It turned out that the original fix was insufficient, because Firefox would fail to even *parse* the script if it contained negative lookbehind in regular expression literals.  As such, this PR replaces the one such literal with a string literal (which, yes, means doubled backslashes); I didn't bother wrapping it in `new RegExp(...)` because highlightjs handles that automatically.

(Really @frangio deserves credit for noticing this and realizing the fix, but since I had some free time figured I'd actually do it and PR this.)