### PR TITLE
Updates for Solidity 0.6.2

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -112,7 +112,9 @@ function hljsDefineSolidity(hljs) {
             'calldataload calldatasize calldatacopy codesize codecopy extcodesize extcodecopy returndatasize returndatacopy extcodehash ' +
             'create create2 call callcode delegatecall staticcall ' +
             'log0 log1 log2 log3 log4 ' +
-            'chainid origin gasprice blockhash coinbase timestamp number difficulty gaslimit'
+            'chainid origin gasprice blockhash coinbase timestamp number difficulty gaslimit',
+        literal:
+            'true false'
     };
 
     //covers the special slot/offset notation in assembly

--- a/solidity.js
+++ b/solidity.js
@@ -82,7 +82,7 @@ function hljsDefineSolidity(hljs) {
             'type ' +
             'blockhash gasleft ' +
             'assert revert require ' +
-	    'Error ' + //Not exactly a builtin? but this seems the best category for it
+            'Error ' + //Not exactly a builtin? but this seems the best category for it
             'sha3 sha256 keccak256 ripemd160 ecrecover addmod mulmod ' +
             'log0 log1 log2 log3 log4' +
             // :NOTE: not really toplevel, but advantageous to have highlighted as if reserved to

--- a/solidity.js
+++ b/solidity.js
@@ -206,6 +206,12 @@ function hljsDefineSolidity(hljs) {
             keywords: SOL_KEYWORDS,
         });
 
+    var SOL_SPECIAL_PARAMETERS = {
+        //special parameters (note: these aren't really handled properly, but this seems like the best compromise for now)
+        className: 'built_in',
+        begin: /(gas|value|salt):/
+    };
+
     function makeBuiltinProps(obj, props) {
         return {
             begin: (isNegativeLookbehindAvailable() ? '(?<!\\$)\\b' : '\\b') + obj + '\\.\\s*',
@@ -236,6 +242,7 @@ function hljsDefineSolidity(hljs) {
             hljs.C_LINE_COMMENT_MODE,
             hljs.C_BLOCK_COMMENT_MODE,
             SOL_NUMBER,
+            SOL_SPECIAL_PARAMETERS,
             { // functions
                 className: 'function',
                 lexemes: SOL_LEXEMES_RE,
@@ -243,6 +250,7 @@ function hljsDefineSolidity(hljs) {
                 contains: [
                     SOL_TITLE_MODE,
                     SOL_FUNC_PARAMS,
+                    SOL_SPECIAL_PARAMETERS,
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE
                 ],
@@ -263,6 +271,7 @@ function hljsDefineSolidity(hljs) {
                     { beginKeywords: 'is', lexemes: SOL_LEXEMES_RE },
                     SOL_TITLE_MODE,
                     SOL_FUNC_PARAMS,
+                    SOL_SPECIAL_PARAMETERS,
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE
                 ]
@@ -315,10 +324,6 @@ function hljsDefineSolidity(hljs) {
                     hljs.inherit(hljs.APOS_STRING_MODE, { className: 'meta-string' }),
                     hljs.inherit(hljs.QUOTE_STRING_MODE, { className: 'meta-string' })
                 ]
-            },
-            { //special parameters (note: these aren't really handled properly, but this seems like the best compromise for now)
-                className: 'built_in',
-                begin: /(gas|value|salt):/
             },
             { //assembly section
                 beginKeywords: 'assembly',

--- a/solidity.js
+++ b/solidity.js
@@ -87,8 +87,7 @@ function hljsDefineSolidity(hljs) {
             'log0 log1 log2 log3 log4' +
             // :NOTE: not really toplevel, but advantageous to have highlighted as if reserved to
             //        avoid newcomers making mistakes due to accidental name collisions.
-            'send transfer call callcode delegatecall staticcall ' +
-            'gas value salt ' //not sure these really belong here but seems a decent place?
+            'send transfer call callcode delegatecall staticcall '
     };
 
     var SOL_ASSEMBLY_KEYWORDS = {
@@ -316,6 +315,10 @@ function hljsDefineSolidity(hljs) {
                     hljs.inherit(hljs.APOS_STRING_MODE, { className: 'meta-string' }),
                     hljs.inherit(hljs.QUOTE_STRING_MODE, { className: 'meta-string' })
                 ]
+            },
+            { //special parameters (note: these aren't really handled properly, but this seems like the best compromise for now)
+                className: 'built_in',
+                begin: /(gas|value|salt):/
             },
             { //assembly section
                 beginKeywords: 'assembly',

--- a/solidity.js
+++ b/solidity.js
@@ -87,7 +87,8 @@ function hljsDefineSolidity(hljs) {
             'log0 log1 log2 log3 log4' +
             // :NOTE: not really toplevel, but advantageous to have highlighted as if reserved to
             //        avoid newcomers making mistakes due to accidental name collisions.
-            'send transfer call callcode delegatecall staticcall ',
+            'send transfer call callcode delegatecall staticcall ' +
+            'gas value salt ' //not sure these really belong here but seems a decent place?
     };
 
     var SOL_ASSEMBLY_KEYWORDS = {


### PR DESCRIPTION
This PR contains updates for Solidity 0.6.2.  Specifically:

1. The literals `true` and `false` are now allowed in assembly mode.

2. I added `gas`,`value`, and `salt` as builtins due to the new function-call syntax?  I'm not sure builtin is really the right place for these, but I couldn't figure out what was better... I mean they're not keywords, surely?  (Like, pretty sure you can still use them as variable names, e.g.)  IDK, if anyone has a better idea, please suggest it.  (I mean ideally we'd only highlight them in context, but that seems really hard!)

(Also, in my previous PR, I accidentally used tabs instead of spaces at one point... oops!  Fixed here.)