### PR TITLE
Add immutable keyword from Solidity 0.6.5

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -63,7 +63,7 @@ function hljsDefineSolidity(hljs) {
 
             'function modifier event constructor fallback receive ' +
             'virtual override ' +
-            'constant anonymous indexed ' +
+            'constant immutable anonymous indexed ' +
             'storage memory calldata ' +
             'external public internal payable pure view private returns ' +
 


### PR DESCRIPTION
Solidity 0.6.5 adds the `immutable` keyword, so, here's a PR to add it to the highlighting.