### PR TITLE
Add highlighting for type(I).interfaceId

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -198,7 +198,9 @@ function hljsDefineSolidity(hljs) {
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
-            built_in: 'gas value selector address send transfer call callcode delegatecall staticcall balance length push pop name creationCode runtimeCode',
+            built_in: 'gas value selector address length push pop ' +
+               'send transfer call callcode delegatecall staticcall balance ' +
+               'name creationCode runtimeCode interfaceId'
         },
         relevance: 2,
     };


### PR DESCRIPTION
One more quick change, I've added `interfaceId` (alongside `runtimeCode` and etc) now that it's been added in Solidity 0.6.7.

Also, that line was getting kind of ridiculously long, so I split it up a bit...