### PR TITLE
Add highlighting for type(T).min & type(T).max

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -200,7 +200,7 @@ function hljsDefineSolidity(hljs) {
         keywords: {
             built_in: 'gas value selector address length push pop ' +
                'send transfer call callcode delegatecall staticcall balance ' +
-               'name creationCode runtimeCode interfaceId'
+               'name creationCode runtimeCode interfaceId min max'
         },
         relevance: 2,
     };


### PR DESCRIPTION
Solidity 0.6.8 adds `type(T).min` and `type(T).max`, so this PR adds highlighting for `min` and `max` when used as members.