### PR TITLE
Remove Yul functions that don't exist in Solidity assembly

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -114,9 +114,7 @@ function hljsDefineSolidity(hljs) {
             'calldataload calldatasize calldatacopy codesize codecopy extcodesize extcodecopy returndatasize returndatacopy extcodehash ' +
             'create create2 call callcode delegatecall staticcall ' +
             'log0 log1 log2 log3 log4 ' +
-            'chainid origin gasprice blockhash coinbase timestamp number difficulty gaslimit ' +
-            //not opcodes, but builtin Yul functions
-            'datasize dataoffset datacopy',
+            'chainid origin gasprice blockhash coinbase timestamp number difficulty gaslimit',
         literal:
             'true false'
     };


### PR DESCRIPTION
So, looks like I made a mistake earlier in adding `datasize`, `dataoffset`, and `datacopy`.  These are Yul functions, yes, but they're not actually available in the dialect of Yul that is Solidity assembly.  For the same reason, I'm not adding any of the Yul keywords `object`, `code`, or `data`, or the Yul functions `setimmutable` or `loadimmutable`, as none of these are actually available in the Solidity assembly Yul dialect.

Sorry about that.  It's confusing how Yul has "dialects"!