### PR TITLE
Add gwei unit

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -72,7 +72,7 @@ function hljsDefineSolidity(hljs) {
             'assembly',
         literal:
             'true false ' +
-            'wei szabo finney ether ' +
+            'wei gwei szabo finney ether ' +
             'seconds minutes hours days weeks years',
         built_in:
             'self ' +   // :NOTE: not a real keyword, but a convention used in storage manipulation libraries


### PR DESCRIPTION
Solidity 0.6.11 is out and adds the `gwei` unit, so I've added that to the list of units.