### PR TITLE
Update package url's to this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "author": "pospi",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/pospi/highlightjs-solidity/issues"
+    "url": "https://github.com/highlightjs/highlightjs-solidity/issues"
   },
-  "homepage": "https://github.com/pospi/highlightjs-solidity#readme",
+  "homepage": "https://github.com/highlightjs/highlightjs-solidity#readme",
   "devDependencies": {
     "highlightjs": "^9.12.0",
     "mocha": "^6.2.1",


### PR DESCRIPTION
The [npmjs](https://www.npmjs.com/package/highlightjs-solidity) page still points to @pospi's personal repo, but it seems that this is the official maintained repo. This PR just updates the `package.json` urls accordingly