### PR TITLE
Update syntax for Solidity 0.7.5

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -141,7 +141,7 @@ function hljsDefineSolidity(hljs) {
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
-            built_in: 'slot offset'
+            built_in: 'slot offset length'
         },
         relevance: 2,
     };
@@ -343,8 +343,8 @@ function hljsDefineSolidity(hljs) {
                 beginKeywords: 'pragma', end: ';',
                 lexemes: SOL_LEXEMES_RE,
                 keywords: {
-                    keyword: 'pragma solidity experimental',
-                    built_in: 'ABIEncoderV2 SMTChecker'
+                    keyword: 'pragma solidity experimental abicoder',
+                    built_in: 'ABIEncoderV2 SMTChecker v1 v2'
                 },
                 contains: [
                     hljs.C_LINE_COMMENT_MODE,


### PR DESCRIPTION
Specifically:

1. In the assembly section, I've added `length` to the list of generic members, since one can now do `x.length` in assembly where `x` is a calldata variable of a dynamically-sized type.

2. I added the `abicoder` pragma.  Following the example of how we handle the different experimental pragmas, I added `v1` and `v2` as builtins; not sure if that's the best place for them (I also considered literals, or treating them as numbers), but I guess it's probably fine?