### PR TITLE
Add Panic to list of builtins alongside Error

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -83,7 +83,7 @@ function hljsDefineSolidity(hljs) {
             'type ' +
             'blockhash gasleft ' +
             'assert revert require ' +
-            'Error ' + //Not exactly a builtin? but this seems the best category for it
+            'Error Panic ' +
             'sha3 sha256 keccak256 ripemd160 ecrecover addmod mulmod ' +
             'log0 log1 log2 log3 log4' +
             // :NOTE: not really toplevel, but advantageous to have highlighted as if reserved to


### PR DESCRIPTION
Solidity 0.8.1 is out and it is now possible to catch panics, so I added `Panic` as a builtin, alongside error.  Also I deleted my comment about not being sure this is the right place because (assuming custom errors are eventually coming) it sure seems like it is.