### PR TITLE
Replace use of `lexemes` with `$pattern`, update version of highlight.js used in testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -304,10 +304,10 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "highlightjs": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/highlightjs/-/highlightjs-9.12.0.tgz",
-      "integrity": "sha512-eAhWMtDZaOZIQdxIP4UEB1vNp/CVXQPdMSihTSuaExhFIRC0BVpXbtP3mTP1hDoGOyh7nbB3cuC3sOPhG5wGDA==",
+    "highlight.js": {
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
+      "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==",
       "dev": true
     },
     "inflight": {
@@ -395,9 +395,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "log-symbols": {
@@ -462,6 +462,18 @@
         "yargs": "13.3.0",
         "yargs-parser": "13.1.1",
         "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "ms": {
@@ -719,9 +731,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yargs": {
@@ -771,9 +783,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/highlightjs/highlightjs-solidity#readme",
   "devDependencies": {
-    "highlightjs": "^9.12.0",
+    "highlight.js": "^10.7.2",
     "mocha": "^6.2.1",
     "parse5": "^5.1.0"
   }

--- a/solidity.js
+++ b/solidity.js
@@ -49,6 +49,7 @@ function hljsDefineSolidity(hljs) {
     var ufixedTypesString = ufixedTypes.join(' ') + ' ';
 
     var SOL_KEYWORDS = {
+        $pattern: SOL_LEXEMES_RE,
         keyword:
             'var bool string ' +
             'int uint ' + intTypesString + uintTypesString +
@@ -92,6 +93,7 @@ function hljsDefineSolidity(hljs) {
     };
 
     var SOL_ASSEMBLY_KEYWORDS = {
+        $pattern: SOL_ASSEMBLY_LEXEMES_RE,
         keyword:
             'assembly ' +
             'let function ' +
@@ -128,6 +130,7 @@ function hljsDefineSolidity(hljs) {
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
+            $pattern: SOL_ASSEMBLY_LEXEMES_RE,
             built_in: 'slot offset'
         },
         relevance: 2,
@@ -142,6 +145,7 @@ function hljsDefineSolidity(hljs) {
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
+            $pattern: SOL_ASSEMBLY_LEXEMES_RE,
             built_in: 'slot offset length'
         },
         relevance: 2,
@@ -221,6 +225,7 @@ function hljsDefineSolidity(hljs) {
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
+            $pattern: SOL_LEXEMES_RE,
             built_in: 'gas value selector address length push pop ' +
                'send transfer call callcode delegatecall staticcall ' +
                'balance code codehash ' +
@@ -232,7 +237,6 @@ function hljsDefineSolidity(hljs) {
     var SOL_TITLE_MODE =
         hljs.inherit(hljs.TITLE_MODE, {
             begin: /[A-Za-z$_][0-9A-Za-z$_]*/,
-            lexemes: SOL_LEXEMES_RE,
             keywords: SOL_KEYWORDS,
         });
 
@@ -248,9 +252,9 @@ function hljsDefineSolidity(hljs) {
             end: /[^A-Za-z0-9$_\.]/,
             excludeBegin: false,
             excludeEnd: true,
-            lexemes: SOL_LEXEMES_RE,
             keywords: {
-                built_in: obj + ' ' + props,
+                $pattern: SOL_LEXEMES_RE,
+                built_in: obj + ' ' + props
             },
             contains: [
                 SOL_RESERVED_MEMBERS
@@ -262,7 +266,6 @@ function hljsDefineSolidity(hljs) {
     return {
         aliases: ['sol'],
         keywords: SOL_KEYWORDS,
-        lexemes: SOL_LEXEMES_RE,
         contains: [
             // basic literal definitions
             SOL_APOS_STRING_MODE,
@@ -275,7 +278,6 @@ function hljsDefineSolidity(hljs) {
             SOL_SPECIAL_PARAMETERS,
             { // functions
                 className: 'function',
-                lexemes: SOL_LEXEMES_RE,
                 beginKeywords: 'function modifier event constructor', end: /[{;]/, excludeEnd: true,
                 contains: [
                     SOL_TITLE_MODE,
@@ -295,11 +297,10 @@ function hljsDefineSolidity(hljs) {
             SOL_RESERVED_MEMBERS,
             { // contracts & libraries & interfaces
                 className: 'class',
-                lexemes: SOL_LEXEMES_RE,
                 beginKeywords: 'contract interface library', end: '{', excludeEnd: true,
                 illegal: /[:"\[\]]/,
                 contains: [
-                    { beginKeywords: 'is', lexemes: SOL_LEXEMES_RE },
+                    { beginKeywords: 'is' },
                     SOL_TITLE_MODE,
                     SOL_FUNC_PARAMS,
                     SOL_SPECIAL_PARAMETERS,
@@ -308,7 +309,6 @@ function hljsDefineSolidity(hljs) {
                 ]
             },
             { // structs & enums
-                lexemes: SOL_LEXEMES_RE,
                 beginKeywords: 'struct enum', end: '{', excludeEnd: true,
                 illegal: /[:"\[\]]/,
                 contains: [
@@ -319,8 +319,10 @@ function hljsDefineSolidity(hljs) {
             },
             { // imports
                 beginKeywords: 'import', end: ';',
-                lexemes: SOL_LEXEMES_RE,
-                keywords: 'import * from as',
+                keywords: {
+                    $pattern: SOL_LEXEMES_RE,
+                    keyword: 'import * from as'
+                },
                 contains: [
                     SOL_TITLE_MODE,
                     SOL_APOS_STRING_MODE,
@@ -333,8 +335,10 @@ function hljsDefineSolidity(hljs) {
             },
             { // using
                 beginKeywords: 'using', end: ';',
-                lexemes: SOL_LEXEMES_RE,
-                keywords: 'using * for',
+                keywords: {
+                    $pattern: SOL_LEXEMES_RE,
+                    keyword: 'using * for'
+                },
                 contains: [
                     SOL_TITLE_MODE,
                     hljs.C_LINE_COMMENT_MODE,
@@ -344,8 +348,8 @@ function hljsDefineSolidity(hljs) {
             { // pragmas
                 className: 'meta',
                 beginKeywords: 'pragma', end: ';',
-                lexemes: SOL_LEXEMES_RE,
                 keywords: {
+                    $pattern: SOL_LEXEMES_RE,
                     keyword: 'pragma solidity experimental abicoder',
                     built_in: 'ABIEncoderV2 SMTChecker v1 v2'
                 },
@@ -366,7 +370,6 @@ function hljsDefineSolidity(hljs) {
                         begin: '{', end: '}',
                         endsParent: true,
                         keywords: SOL_ASSEMBLY_KEYWORDS,
-                        lexemes: SOL_ASSEMBLY_LEXEMES_RE,
                         contains: [
                             SOL_APOS_STRING_MODE,
                             SOL_QUOTE_STRING_MODE,
@@ -380,7 +383,6 @@ function hljsDefineSolidity(hljs) {
                             { //block within assembly; note the lack of endsParent
                                 begin: '{', end: '}',
                                 keywords: SOL_ASSEMBLY_KEYWORDS,
-                                lexemes: SOL_ASSEMBLY_LEXEMES_RE,
                                 contains: [
                                     SOL_APOS_STRING_MODE,
                                     SOL_QUOTE_STRING_MODE,

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const parse5 = require('parse5');
 
-const hljs = require('highlightjs');
+const hljs = require('highlight.js');
 const defineSolidity = require('.');
 
 defineSolidity(hljs);


### PR DESCRIPTION
Per @joshgoebel's request, this PR replaces the uses of `lexemes` with `keywords.$pattern` (and updates the version of highlight.js used in testing so that this will actually work).

...except, it doesn't work.  One of the tests checks that the `tx` in `id$tx` is not recognized as a builtin, because dollar signs are legal in Solidity identifiers.  But on this PR, this test fails.  It worked fine with `lexemes`... am I doing something wrong here?

I'll leave this PR up for now even though it's failing, in the hopes that maybe I can get some advice about how to fix this.