### PR TITLE
Add Yul and register it in addition to Solidity

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -69,12 +69,12 @@ var SOL_ASSEMBLY_KEYWORDS = {
 
 var HEX_APOS_STRING_MODE = {
     className: 'string',
-    begin: /hex'(([0-9a-fA-F]{2}_?)*[0-9a-fA-F]{2})?'/, //please also update HEX_QUOTE_STRING_MODE
+    begin: /\bhex'(([0-9a-fA-F]{2}_?)*[0-9a-fA-F]{2})?'/, //please also update HEX_QUOTE_STRING_MODE
 };
 
 var HEX_QUOTE_STRING_MODE = {
     className: 'string',
-    begin: /hex"(([0-9a-fA-F]{2}_?)*[0-9a-fA-F]{2})?"/, //please also update HEX_APOS_STRING_MODE
+    begin: /\bhex"(([0-9a-fA-F]{2}_?)*[0-9a-fA-F]{2})?"/, //please also update HEX_APOS_STRING_MODE
 };
 
 //I've set these up exactly like hljs's builtin STRING_MODEs,
@@ -82,14 +82,14 @@ var HEX_QUOTE_STRING_MODE = {
 function solAposStringMode(hljs) {
     return hljs.inherit(
         hljs.APOS_STRING_MODE, //please also update solQuoteStringMode
-        { begin: /(unicode)?'/ }
+        { begin: /(\bunicode)?'/ }
     );
 }
 
 function solQuoteStringMode(hljs) {
     return hljs.inherit(
         hljs.QUOTE_STRING_MODE, //please also update solAposStringMode
-        { begin: /(unicode)?"/ }
+        { begin: /(\bunicode)?"/ }
     );
 }
 

--- a/solidity.js
+++ b/solidity.js
@@ -93,33 +93,6 @@ function solQuoteStringMode(hljs) {
     );
 }
 
-//covers the special slot/offset notation in assembly
-//(old-style, with an underscore)
-var SOL_ASSEMBLY_MEMBERS_OLD = {
-    begin: /_/,
-    end: /[^A-Za-z0-9$.]/,
-    excludeBegin: true,
-    excludeEnd: true,
-    keywords: {
-        built_in: 'slot offset'
-    },
-    relevance: 2,
-};
-
-//covers the special slot/offset notation in assembly
-//(new-style, with a dot; keeping this separate as it
-//may be expanded in the future)
-var SOL_ASSEMBLY_MEMBERS = {
-    begin: /\./,
-    end: /[^A-Za-z0-9$.]/,
-    excludeBegin: true,
-    excludeEnd: true,
-    keywords: {
-        built_in: 'slot offset length'
-    },
-    relevance: 2,
-};
-
 //in assembly, identifiers can contain periods (but may not start with them)
 var SOL_ASSEMBLY_LEXEMES_RE = /[A-Za-z_$][A-Za-z_$0-9.]*/;
 
@@ -140,9 +113,7 @@ function baseAssembly(hljs) {
             HEX_QUOTE_STRING_MODE,
             hljs.C_LINE_COMMENT_MODE,
             hljs.C_BLOCK_COMMENT_MODE,
-            SOL_NUMBER,
-            SOL_ASSEMBLY_MEMBERS,
-            SOL_ASSEMBLY_MEMBERS_OLD
+            SOL_NUMBER
         ]
     };
 }
@@ -294,7 +265,40 @@ function hljsDefineSolidity(hljs) {
         };
     }
 
+    //covers the special slot/offset notation in assembly
+    //(old-style, with an underscore)
+    var SOL_ASSEMBLY_MEMBERS_OLD = {
+        begin: /_/,
+        end: /[^A-Za-z0-9$.]/,
+        excludeBegin: true,
+        excludeEnd: true,
+        keywords: {
+            built_in: 'slot offset'
+        },
+        relevance: 2,
+    };
+
+    //covers the special slot/offset notation in assembly
+    //(new-style, with a dot; keeping this separate as it
+    //may be expanded in the future)
+    var SOL_ASSEMBLY_MEMBERS = {
+        begin: /\./,
+        end: /[^A-Za-z0-9$.]/,
+        excludeBegin: true,
+        excludeEnd: true,
+        keywords: {
+            built_in: 'slot offset length'
+        },
+        relevance: 2,
+    };
+
     var BASE_ASSEMBLY_ENVIRONMENT = baseAssembly(hljs);
+    var SOL_ASSEMBLY_ENVIRONMENT = hljs.inherit(BASE_ASSEMBLY_ENVIRONMENT, {
+        contains: BASE_ASSEMBLY_ENVIRONMENT.contains.concat([
+            SOL_ASSEMBLY_MEMBERS,
+            SOL_ASSEMBLY_MEMBERS_OLD
+        ])
+    });
 
     return {
         aliases: ['sol'],
@@ -399,13 +403,13 @@ function hljsDefineSolidity(hljs) {
                 contains: [
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE,
-                    hljs.inherit(BASE_ASSEMBLY_ENVIRONMENT, { //the actual *block* in the assembly section
+                    hljs.inherit(SOL_ASSEMBLY_ENVIRONMENT, { //the actual *block* in the assembly section
                         begin: '{', end: '}',
                         endsParent: true,
-                        contains: BASE_ASSEMBLY_ENVIRONMENT.contains.concat([
-                            hljs.inherit(BASE_ASSEMBLY_ENVIRONMENT, { //block within assembly
+                        contains: SOL_ASSEMBLY_ENVIRONMENT.contains.concat([
+                            hljs.inherit(SOL_ASSEMBLY_ENVIRONMENT, { //block within assembly
                                 begin: '{', end: '}',
-                                contains: BASE_ASSEMBLY_ENVIRONMENT.contains.concat(['self'])
+                                contains: SOL_ASSEMBLY_ENVIRONMENT.contains.concat(['self'])
                             })
                         ])
                     })

--- a/solidity.js
+++ b/solidity.js
@@ -26,10 +26,9 @@ function isNegativeLookbehindAvailable() {
 //also, all instances of \b (word boundary) have been replaced with (?<!\$)\b
 //NOTE: we use string rather than regexp in the case where negative lookbehind
 //is allowed to avoid Firefox parse errors; sorry about the resulting double backslashes!
+var SOL_NUMBER_RE = /-?(\b0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|(\b[1-9](_?\d)*(\.((\d_?)*\d)?)?|\.\d(_?\d)*)([eE][-+]?\d(_?\d)*)?|\b0)/;
 if (isNegativeLookbehindAvailable()) {
-    var SOL_NUMBER_RE = '-?((?<!\\$)\\b0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|((?<!\\$)\\b[1-9](_?\\d)*(\\.((\\d_?)*\\d)?)?|\\.\\d(_?\\d)*)([eE][-+]?\\d(_?\\d)*)?|(?<!\\$)\\b0)';
-} else {
-    var SOL_NUMBER_RE = /-?(\b0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|(\b[1-9](_?\d)*(\.((\d_?)*\d)?)?|\.\d(_?\d)*)([eE][-+]?\d(_?\d)*)?|\b0)/;
+    SOL_NUMBER_RE = SOL_NUMBER_RE.source.replace(/\\b/g, '(?<!\\$)\\b');
 }
 
 var SOL_NUMBER = {

--- a/test.js
+++ b/test.js
@@ -8,8 +8,8 @@ defineSolidity(hljs);
 
 // Receives a Solidity snippet and returns an array of [type, text] tuples.
 // Type is the detected token type, and text the corresponding source text.
-function getTokens(source) {
-  const { value } = hljs.highlight('solidity', source);
+function getTokens(source, language = 'solidity') {
+  const { value } = hljs.highlight(language, source);
   const frag = parse5.parseFragment(value);
 
   return frag.childNodes.map(function (node) {
@@ -82,5 +82,13 @@ it('builtins', function () {
 
   for (const b of builtins) {
     assert.deepEqual(getTokens(b), [['built_in', b]]);
+  }
+});
+
+it('yul keywords', function () {
+  const keywords = ['object', 'code', 'data'];
+
+  for (const keyword of keywords) {
+    assert.deepEqual(getTokens(keyword, 'yul'), [['keyword', keyword]]);
   }
 });


### PR DESCRIPTION
This PR makes it so that this package provides Yul highlighting in addition to Solidity highlighting.  Now, you may say, isn't just Yul just Solidity assembly?  Well, yes, but it has a few additional keywords and builtins.  I didn't want to add those to our list of keywords and builtins in Solidity assembly, though, because, well, they didn't exist there.  So instead I made Yul separate and made it so that the package will register Yul as a second language in addition to Solidity.  (@joshgoebel, I hope that's OK with all the transition stuff; I didn't want to make a separate `highlight-yul` package, because, well, it would largely consist of copied code.)

This entailed moving a bunch of the setup code outside the `hljsDefineSolidity` function so that it could be used by both Solidity and Yul; it also required turning into explicit functions of `hljs` constants that had previously only depended on it implicitly.

In order to keep things maintainable -- because we would now have three separate assembly environments -- I defined a base assembly environment as a starting point, and then changed the others to be based off of that using `hljs.inherit`.

(I remain a bit unclear on the status of `u256` as a keyword within Yul/Solidity, but, well, I'll just leave that for now; it is documented, after all, even if it doesn't work.)

So, now this package will provide both Solidity and Yul highlighting, as separate languages!

**Edit**: Since `.slot`, `.offset`, etc, are only meaningful in Solidity assembly, not standalone Yul, I made a change to restrict highlighting of those to Solidity assembly and keep that out of the base assembly, so they won't be highlighted in standalone Yul.

**Edit**: Actually, while I was at it, I went and added function title/params highlighting to assembly like we have in Solidity.  I thought about adding some sort of class title highlighting for Yul (considering an `object` as a sort of class), but didn't bother; I'm not convinced that really makes sense.