### PR TITLE
Add fallback, receive, error as types of function declarations

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -276,7 +276,7 @@ function hljsDefineSolidity(hljs) {
             { // functions
                 className: 'function',
                 lexemes: SOL_LEXEMES_RE,
-                beginKeywords: 'function modifier event constructor', end: /[{;]/, excludeEnd: true,
+                beginKeywords: 'function modifier event constructor fallback receive error', end: /[{;]/, excludeEnd: true,
                 contains: [
                     SOL_TITLE_MODE,
                     SOL_FUNC_PARAMS,


### PR DESCRIPTION
Just noticed that I'd totally missed updating this.  Obviously `fallback`, `receive`, and `error` all got added to the list of keywords, but not here.  So I've added them here now.  (Obviously `error` isn't actually a type of function declaration, but it makes sense to highlight it the same way, and `event` is already included here for the same reason.)