### PR TITLE
Add operator and punctuation highlighting

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -125,6 +125,8 @@ function baseAssembly(hljs) {
         ]
     };
 
+    //note: we always put operators below comments so
+    //it won't interfere with comments
     var SOL_ASSEMBLY_OPERATORS = {
         className: 'operator',
         begin: /:=|->/
@@ -249,6 +251,8 @@ function hljsDefineSolidity(hljs) {
             'send transfer call callcode delegatecall staticcall '
     };
 
+    //note: we always put operators below comments so
+    //it won't interfere with comments
     var SOL_OPERATORS = {
         className: 'operator',
         begin: /[+\-!~*\/%<>&^|=]/ //excluding ?: because having : as operator causes problems
@@ -440,9 +444,9 @@ function hljsDefineSolidity(hljs) {
                 keywords: 'using for',
                 contains: [
                     SOL_TITLE_MODE,
-                    SOL_OPERATORS,
                     hljs.C_LINE_COMMENT_MODE,
-                    hljs.C_BLOCK_COMMENT_MODE
+                    hljs.C_BLOCK_COMMENT_MODE,
+                    SOL_OPERATORS
                 ]
             },
             { // pragmas

--- a/solidity.js
+++ b/solidity.js
@@ -125,6 +125,16 @@ function baseAssembly(hljs) {
         ]
     };
 
+    var SOL_ASSEMBLY_OPERATORS = {
+        className: 'operator',
+        begin: /:=|->/
+    };
+
+    var SOL_ASSEMBLY_PUNCTUATION = {
+        className: 'punctuation',
+        begin: /[{}().,]/
+    };
+
     return {
         keywords: SOL_ASSEMBLY_KEYWORDS,
         lexemes: SOL_ASSEMBLY_LEXEMES_RE,
@@ -136,6 +146,8 @@ function baseAssembly(hljs) {
             hljs.C_LINE_COMMENT_MODE,
             hljs.C_BLOCK_COMMENT_MODE,
             SOL_NUMBER,
+            SOL_ASSEMBLY_OPERATORS,
+            SOL_ASSEMBLY_PUNCTUATION,
             { // functions
                 className: 'function',
                 lexemes: SOL_ASSEMBLY_LEXEMES_RE,
@@ -144,9 +156,11 @@ function baseAssembly(hljs) {
                     SOL_ASSEMBLY_TITLE_MODE,
                     SOL_ASSEMBLY_FUNC_PARAMS,
                     hljs.C_LINE_COMMENT_MODE,
-                    hljs.C_BLOCK_COMMENT_MODE
+                    hljs.C_BLOCK_COMMENT_MODE,
+                    SOL_ASSEMBLY_OPERATORS,
+                    SOL_ASSEMBLY_PUNCTUATION
                 ],
-            },
+            }
         ]
     };
 }
@@ -235,8 +249,17 @@ function hljsDefineSolidity(hljs) {
             'send transfer call callcode delegatecall staticcall '
     };
 
-    //NOTE: including "*" as a "lexeme" because we use it as a "keyword" below
-    var SOL_LEXEMES_RE = /[A-Za-z_$][A-Za-z_$0-9]*|\*/;
+    var SOL_OPERATORS = {
+        className: 'operator',
+        begin: /[+\-!~*\/%<>&^|=]/ //excluding ?: because having : as operator causes problems
+    };
+
+    var SOL_PUNCTUATION = {
+        className: 'punctuation',
+        begin: /[{}()\[\].,?:;]/ //including ?: as punctuation because having : as operator causes problems
+    };
+
+    var SOL_LEXEMES_RE = /[A-Za-z_$][A-Za-z_$0-9]*/;
 
     var SOL_FUNC_PARAMS = {
         className: 'params',
@@ -350,6 +373,8 @@ function hljsDefineSolidity(hljs) {
             hljs.C_BLOCK_COMMENT_MODE,
             SOL_NUMBER,
             SOL_SPECIAL_PARAMETERS,
+            SOL_OPERATORS,
+            SOL_PUNCTUATION,
             { // functions
                 className: 'function',
                 lexemes: SOL_LEXEMES_RE,
@@ -397,7 +422,7 @@ function hljsDefineSolidity(hljs) {
             { // imports
                 beginKeywords: 'import', end: ';',
                 lexemes: SOL_LEXEMES_RE,
-                keywords: 'import * from as',
+                keywords: 'import from as',
                 contains: [
                     SOL_TITLE_MODE,
                     SOL_APOS_STRING_MODE,
@@ -405,15 +430,17 @@ function hljsDefineSolidity(hljs) {
                     HEX_APOS_STRING_MODE,
                     HEX_QUOTE_STRING_MODE,
                     hljs.C_LINE_COMMENT_MODE,
-                    hljs.C_BLOCK_COMMENT_MODE
+                    hljs.C_BLOCK_COMMENT_MODE,
+                    SOL_OPERATORS
                 ]
             },
             { // using
                 beginKeywords: 'using', end: ';',
                 lexemes: SOL_LEXEMES_RE,
-                keywords: 'using * for',
+                keywords: 'using for',
                 contains: [
                     SOL_TITLE_MODE,
+                    SOL_OPERATORS,
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE
                 ]

--- a/test.js
+++ b/test.js
@@ -92,3 +92,11 @@ it('yul keywords', function () {
     assert.deepEqual(getTokens(keyword, 'yul'), [['keyword', keyword]]);
   }
 });
+
+it('yul operators', function () {
+  const operators = ['->', ':='];
+
+  for (const operator of operators) {
+    assert.deepEqual(getTokens(operator, 'yul'), [['operator', operator]]);
+  }
+});


### PR DESCRIPTION
This PR adds operator and punctuation highlighting for Solidity and Yul.  Well -- I did some of this in maybe an iffy way, but, well, obviously it can be changed if need be.

For Yul this was straightforward; I added `:=` and `->` as operators, and the obvious things as punctuation.  Arguably `->` should be punctuation, but it seemed worth highlighting as an operator to me.

For Solidity... well, Solidity has a number of operators, but they're all made of the same few characters, so I just checked for those characters.  (So, `=>` will be highlighted as an operator, which makes sense to me.)  For punctuation I put the obvious things.

Except... I did one thing that is maybe kind of off; I put `?` and `:` as punctuation.  Now, `?` should be an operator, right?  It's the ternary operator.  Problem is, then `:` should be an operator too.  And `:` occurs in a lot of contexts where it is not in fact an operator, but we don't really have a good way of checking for that right now.  So I thought, what if I just classed them as punctuation instead?  Maybe that'd be OK?  Like I said, let me know what you think.

Note I didn't include punctuation highlighting inside function parameters.

Also I removed `*` as a possible lexeme and removed it from keywords, adding operator highlighting to those contexts instead so it'll be highlighted as an operator.

I also added a rudimentary test.