### PR TITLE
Syntax update for Solidity 0.8.5: Add `verbatim` builtin in assembly

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -102,6 +102,19 @@ function baseAssembly(hljs) {
     //in assembly, identifiers can contain periods (but may not start with them)
     var SOL_ASSEMBLY_LEXEMES_RE = /[A-Za-z_$][A-Za-z_$0-9.]*/;
 
+    var SOL_ASSEMBLY_VERBATIM_RE = /\bverbatim_[1-9]?[0-9]i_[1-9]?[0-9]o\b(?!\$)/;
+    if (isNegativeLookbehindAvailable()) {
+        //replace just first \b
+        SOL_ASSEMBLY_VERBATIM_RE = SOL_ASSEMBLY_VERBATIM_RE.source.replace(/\\b/, '(?<!\\$)\\b');
+    }
+
+    //highlights the "verbatim" builtin. making a separate mode for this due to
+    //its variability.
+    var SOL_ASSEMBLY_VERBATIM_MODE = {
+        className: "built_in",
+        begin: SOL_ASSEMBLY_VERBATIM_RE
+    };
+
     var SOL_ASSEMBLY_TITLE_MODE =
         hljs.inherit(hljs.TITLE_MODE, {
             begin: /[A-Za-z$_][0-9A-Za-z$_]*/,
@@ -135,6 +148,7 @@ function baseAssembly(hljs) {
             HEX_QUOTE_STRING_MODE,
             hljs.C_LINE_COMMENT_MODE,
             hljs.C_BLOCK_COMMENT_MODE,
+            SOL_ASSEMBLY_VERBATIM_MODE,
             SOL_NUMBER,
             { // functions
                 className: 'function',

--- a/solidity.js
+++ b/solidity.js
@@ -26,7 +26,7 @@ function isNegativeLookbehindAvailable() {
 //also, all instances of \b (word boundary) have been replaced with (?<!\$)\b
 //NOTE: we use string rather than regexp in the case where negative lookbehind
 //is allowed to avoid Firefox parse errors; sorry about the resulting double backslashes!
-var SOL_NUMBER_RE = /-?(\b0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|(\b[1-9](_?\d)*(\.((\d_?)*\d)?)?|\.\d(_?\d)*)([eE][-+]?\d(_?\d)*)?|\b0)/;
+var SOL_NUMBER_RE = /-?(\b0[xX]([a-fA-F0-9]_?)*[a-fA-F0-9]|(\b[1-9](_?\d)*(\.((\d_?)*\d)?)?|\.\d(_?\d)*)([eE][-+]?\d(_?\d)*)?|\b0)(?!\w|\$)/;
 if (isNegativeLookbehindAvailable()) {
     SOL_NUMBER_RE = SOL_NUMBER_RE.source.replace(/\\b/g, '(?<!\\$)\\b');
 }

--- a/test.js
+++ b/test.js
@@ -92,3 +92,12 @@ it('yul keywords', function () {
     assert.deepEqual(getTokens(keyword, 'yul'), [['keyword', keyword]]);
   }
 });
+
+it('verbatim', function () {
+  for (let inArgs = 0; inArgs < 100; inArgs++) {
+    for (let outArgs = 0; outArgs < 100; outArgs++) {
+      const verbatim = `verbatim_${inArgs}i_${outArgs}o`;
+      assert.deepEqual(getTokens(verbatim, 'yul'), [['built_in', verbatim]]);
+    }
+  }
+});


### PR DESCRIPTION
This PR adds highlighting for the `verbatim` family of assembly builtins introduced in 0.8.5.  Rather than handling these by the crazy way I handled fixed-point types (I should probably redo those at some point...) I just used a regular expression.  So this means it gets its own mode rather than just being a keyword.

Also, while I was at it, I added a second commit to require that numbers are followed by a word break, since we didn't have that previously.