### PR TITLE
Add special highlighting for `".metadata"` and `'.metadata'` in Yul

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -482,9 +482,28 @@ function hljsDefineYul(hljs) {
         literal: SOL_ASSEMBLY_KEYWORDS.literal
     };
 
+    var BASE_ASSEMBLY_ENVIRONMENT = baseAssembly(hljs);
+
+    var YUL_APOS_METADATA_STRING_MODE = {
+        className: "built_in",
+        begin: /'\.metadata'/
+    };
+
+    var YUL_QUOTE_METADATA_STRING_MODE = {
+        className: "built_in",
+        begin: /"\.metadata"/
+    };
+
     return hljs.inherit(
-        baseAssembly(hljs),
-        { keywords: YUL_KEYWORDS }
+        BASE_ASSEMBLY_ENVIRONMENT,
+        {
+            keywords: YUL_KEYWORDS,
+            contains: [
+                //prepend these so they take priority
+                YUL_APOS_METADATA_STRING_MODE,
+                YUL_QUOTE_METADATA_STRING_MODE,
+            ].concat(BASE_ASSEMBLY_ENVIRONMENT.contains)
+        }
     );
 }
 

--- a/test.js
+++ b/test.js
@@ -101,3 +101,8 @@ it('verbatim', function () {
     }
   }
 });
+
+it('metadata', function () {
+  const metadata = '".metadata"';
+  assert.deepEqual(getTokens(metadata, 'yul'), [['built_in', metadata]]);
+});


### PR DESCRIPTION
OK, I'm not sure whether this one is a good idea, but, well, that's what reviewers are for!

As of solc 0.8.6, in Yul (proper Yul only, not Solidity assembly), string literals evaluating to `".metadata"` have a special meaning in some contexts.  To capture that, this PR adds highlighting for the string literals `".metadata"` and `'.metadata'`.  It doesn't include other equivalent string literals, because they're much less likely to be used.

I'm not sure there's an appropriate class for this, which is why I'm not sure this PR is a good idea?  After discussing things with @gnidan, I went with highlighting it as a builtin, but I'm not really sure that's right.

Anyway, I'll see what you reviewers think...