### PR TITLE
Remove definer to avoid build problems

### DIFF
--- a/solidity.js
+++ b/solidity.js
@@ -505,5 +505,3 @@ module.exports = function(hljs) {
     hljs.registerLanguage('solidity', hljsDefineSolidity);
     hljs.registerLanguage('yul', hljsDefineYul);
 };
-
-module.exports.definer = hljsDefineSolidity;


### PR DESCRIPTION
It seems this `definer` causes a build warning; seems the build process doesn't like it if default and named exports are mixed.  So, let's just remove this?  This is going to be a breaking release after all. :)