### PR TITLE
Include dist & src in npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.2.2",
   "description": "highlight.js syntax definition for Ethereum's Solidity language",
   "main": "src/index.js",
-  "files": [],
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
Oops, I almost published without `dist`!  This PR makes sure `dist` gets included in the actual NPM tarball!