### PR TITLE
Update syntax for Solidity 0.8.8

### DIFF
--- a/src/languages/solidity.js
+++ b/src/languages/solidity.js
@@ -131,11 +131,11 @@ function hljsDefineSolidity(hljs) {
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
-            built_in: 'gas value selector address length push pop ' +
-                'send transfer call callcode delegatecall staticcall ' +
-                'balance code codehash ' +
-                'wrap unwrap ' +
-                'name creationCode runtimeCode interfaceId min max'
+            built_in: 'gas value selector address length push pop ' + //members of external functions; members of arrays
+                'send transfer call callcode delegatecall staticcall ' + //members of addresses
+                'balance code codehash ' + //more members of addresses
+                'wrap unwrap ' + //members of UDVTs (the types not the values)
+                'name creationCode runtimeCode interfaceId min max' //members of type(...)
         },
         relevance: 2,
     };

--- a/src/languages/solidity.js
+++ b/src/languages/solidity.js
@@ -81,6 +81,7 @@ function hljsDefineSolidity(hljs) {
 
             'import from as using pragma ' +
             'contract interface library is abstract ' +
+            'type ' +
             'assembly',
         literal:
             'true false ' +
@@ -91,7 +92,6 @@ function hljsDefineSolidity(hljs) {
             'this super selfdestruct suicide ' +
             'now ' +
             'msg block tx abi ' +
-            'type ' +
             'blockhash gasleft ' +
             'assert require ' +
             'Error Panic ' +
@@ -132,9 +132,10 @@ function hljsDefineSolidity(hljs) {
         excludeEnd: true,
         keywords: {
             built_in: 'gas value selector address length push pop ' +
-               'send transfer call callcode delegatecall staticcall ' +
-               'balance code codehash ' +
-               'name creationCode runtimeCode interfaceId min max'
+                'send transfer call callcode delegatecall staticcall ' +
+                'balance code codehash ' +
+                'wrap unwrap ' +
+                'name creationCode runtimeCode interfaceId min max'
         },
         relevance: 2,
     };


### PR DESCRIPTION
Syntax updates for Solidity 0.8.8:

1. I reclassified `type` as a keyword rather than a builtin, now that it can be used for custom type declarations.

2. I highlighed `wrap` and `unwrap` as builtins when used as a member of something else.  I'm a little uncertain whether this is a good idea; it's possible that `wrap` and `unwrap` functions are sufficiently common that highlighting this would be annoying, and it would be better to just omit highlighting for these. So, uh, please let me know what you think of this.  (@gnidan, I can't add you as a reviewer, but do you have an opinion on this?)