### PR TITLE
Add highlighting for .address & .selector in Solidity assembly

### DIFF
--- a/src/languages/solidity.js
+++ b/src/languages/solidity.js
@@ -194,7 +194,7 @@ function hljsDefineSolidity(hljs) {
         excludeBegin: true,
         excludeEnd: true,
         keywords: {
-            built_in: 'slot offset length'
+            built_in: 'slot offset length address selector'
         },
         relevance: 2,
     };


### PR DESCRIPTION
Solidity 0.8.10 adds the syntax `x.address` and `x.selector` when in a Solidity assembly block.  So, adding highlighting for those here.