### PR TITLE
Restrict highlighting of verbatim to standalone Yul

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -100,19 +100,6 @@ function baseAssembly(hljs) {
     //in assembly, identifiers can contain periods (but may not start with them)
     var SOL_ASSEMBLY_LEXEMES_RE = /[A-Za-z_$][A-Za-z_$0-9.]*/;
 
-    var SOL_ASSEMBLY_VERBATIM_RE = /\bverbatim_[1-9]?[0-9]i_[1-9]?[0-9]o\b(?!\$)/;
-    if (isNegativeLookbehindAvailable()) {
-        //replace just first \b
-        SOL_ASSEMBLY_VERBATIM_RE = SOL_ASSEMBLY_VERBATIM_RE.source.replace(/\\b/, '(?<!\\$)\\b');
-    }
-
-    //highlights the "verbatim" builtin. making a separate mode for this due to
-    //its variability.
-    var SOL_ASSEMBLY_VERBATIM_MODE = {
-        className: "built_in",
-        begin: SOL_ASSEMBLY_VERBATIM_RE
-    };
-
     var SOL_ASSEMBLY_TITLE_MODE =
         hljs.inherit(hljs.TITLE_MODE, {
             begin: /[A-Za-z$_][0-9A-Za-z$_]*/,
@@ -153,7 +140,6 @@ function baseAssembly(hljs) {
             HEX_QUOTE_STRING_MODE,
             hljs.C_LINE_COMMENT_MODE,
             hljs.C_BLOCK_COMMENT_MODE,
-            SOL_ASSEMBLY_VERBATIM_MODE,
             SOL_NUMBER,
             SOL_ASSEMBLY_OPERATORS,
             { // functions

--- a/src/languages/yul.js
+++ b/src/languages/yul.js
@@ -8,7 +8,11 @@
  * @since:   2016-07-01
  */
 
-const { SOL_ASSEMBLY_KEYWORDS, baseAssembly } = require("../common.js");
+const {
+    SOL_ASSEMBLY_KEYWORDS,
+    baseAssembly,
+    isNegativeLookbehindAvailable
+} = require("../common.js");
 
 function hljsDefineYul(hljs) {
 
@@ -22,9 +26,29 @@ function hljsDefineYul(hljs) {
         literal: SOL_ASSEMBLY_KEYWORDS.literal
     };
 
+    var YUL_VERBATIM_RE = /\bverbatim_[1-9]?[0-9]i_[1-9]?[0-9]o\b(?!\$)/;
+    if (isNegativeLookbehindAvailable()) {
+        //replace just first \b
+        YUL_VERBATIM_RE = YUL_VERBATIM_RE.source.replace(/\\b/, '(?<!\\$)\\b');
+    }
+
+    //highlights the "verbatim" builtin. making a separate mode for this due to
+    //its variability.
+    var YUL_VERBATIM_MODE = {
+        className: "built_in",
+        begin: YUL_VERBATIM_RE
+    };
+
+    var BASE_ASSEMBLY_ENVIRONMENT = baseAssembly(hljs);
+
     return hljs.inherit(
-        baseAssembly(hljs),
-        { keywords: YUL_KEYWORDS }
+        BASE_ASSEMBLY_ENVIRONMENT,
+        {
+            keywords: YUL_KEYWORDS,
+            contains: BASE_ASSEMBLY_ENVIRONMENT.contains.concat([
+                YUL_VERBATIM_MODE
+            ])
+        }
     );
 }
 

--- a/test.js
+++ b/test.js
@@ -102,6 +102,7 @@ it('yul operators', function () {
 });
 
 it('verbatim', function () {
+  this.timeout(4000);
   for (let inArgs = 0; inArgs < 100; inArgs++) {
     for (let outArgs = 0; outArgs < 100; outArgs++) {
       const verbatim = `verbatim_${inArgs}i_${outArgs}o`;


### PR DESCRIPTION
It turns out that `verbatim` currently only exists in standalone Yul, not in Solidity assembly.  So, I restricted it to standalone Yul.  We can revert this commit later if `verbatim` is eventually brought to Solidity assembly, which I believe is [planned](https://github.com/ethereum/solidity/issues/12067).

Also I upped the timeout on the test of `verbatim`, because it was timing out when I ran it locally (probably due to being in a meeting at the time :P ).