### PR TITLE
Update syntax highlighting for Solidity 0.8.11

### DIFF
--- a/src/languages/solidity.js
+++ b/src/languages/solidity.js
@@ -239,7 +239,7 @@ function hljsDefineSolidity(hljs) {
             makeBuiltinProps('msg', 'gas value data sender sig'),
             makeBuiltinProps('block', 'blockhash coinbase difficulty gaslimit basefee number timestamp chainid'),
             makeBuiltinProps('tx', 'gasprice origin'),
-            makeBuiltinProps('abi', 'decode encode encodePacked encodeWithSelector encodeWithSignature'),
+            makeBuiltinProps('abi', 'decode encode encodePacked encodeWithSelector encodeWithSignature encodeCall'),
             makeBuiltinProps('bytes', 'concat'),
             SOL_RESERVED_MEMBERS,
             { // contracts & libraries & interfaces


### PR DESCRIPTION
There's only one thing to add: Syntax highlighting for the new builtin function `abi.encodeCall`.