### PR TITLE
Add highlighting for string.concat

### DIFF
--- a/src/languages/solidity.js
+++ b/src/languages/solidity.js
@@ -241,6 +241,7 @@ function hljsDefineSolidity(hljs) {
             makeBuiltinProps('tx', 'gasprice origin'),
             makeBuiltinProps('abi', 'decode encode encodePacked encodeWithSelector encodeWithSignature encodeCall'),
             makeBuiltinProps('bytes', 'concat'),
+            makeBuiltinProps('string', 'concat'),
             SOL_RESERVED_MEMBERS,
             { // contracts & libraries & interfaces
                 className: 'class',


### PR DESCRIPTION
Solidity 0.8.12 adds the function `string.concat`, so, I've added highlighting for it as a builtin.