### PR TITLE
Syntax updates for Solidity 0.8.13

### DIFF
--- a/src/languages/solidity.js
+++ b/src/languages/solidity.js
@@ -314,6 +314,8 @@ function hljsDefineSolidity(hljs) {
                 contains: [
                     hljs.C_LINE_COMMENT_MODE,
                     hljs.C_BLOCK_COMMENT_MODE,
+                    hljs.inherit(SOL_APOS_STRING_MODE, { className: 'meta-string' }), //going to count "memory-safe" etc as meta-strings
+                    hljs.inherit(SOL_QUOTE_STRING_MODE, { className: 'meta-string' }),
                     hljs.inherit(SOL_ASSEMBLY_ENVIRONMENT, { //the actual *block* in the assembly section
                         begin: '{', end: '}',
                         endsParent: true,

--- a/src/languages/solidity.js
+++ b/src/languages/solidity.js
@@ -79,7 +79,7 @@ function hljsDefineSolidity(hljs) {
             'storage memory calldata ' +
             'external public internal payable pure view private returns ' +
 
-            'import from as using pragma ' +
+            'import from as using global pragma ' +
             'contract interface library is abstract ' +
             'type ' +
             'assembly',
@@ -285,7 +285,7 @@ function hljsDefineSolidity(hljs) {
             { // using
                 beginKeywords: 'using', end: ';',
                 lexemes: SOL_LEXEMES_RE,
-                keywords: 'using for',
+                keywords: 'using for global',
                 contains: [
                     SOL_TITLE_MODE,
                     hljs.C_LINE_COMMENT_MODE,


### PR DESCRIPTION
Two updates for this one:

1. I added highlighting for the new `global` keyword.  I guess really this is only a keyword in the context of a `using` declaration, but I highlighted it generally for simplicity?  If you think that's a bad idea though I can change it to only highlight inside a `using` declaration.
2. I allowed string literals inbetween the word `assembly` and the actual assembly-block that follows; this is intended to allow for highlighting in the new syntax `assembly ("memory-safe") { ... }`.  I figured it makes sense to mark such strings as meta strings, rather than ordinary strings?  This doesn't actually make a difference to Truffle's coloring, we color them the same. :P