### PR TITLE
Add highlighting for prevrandao for Solidity 0.8.18

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -59,7 +59,7 @@ var SOL_ASSEMBLY_KEYWORDS = {
         'calldataload calldatasize calldatacopy codesize codecopy extcodesize extcodecopy returndatasize returndatacopy extcodehash ' +
         'create create2 call callcode delegatecall staticcall ' +
         'log0 log1 log2 log3 log4 ' +
-        'chainid origin gasprice basefee blockhash coinbase timestamp number difficulty gaslimit',
+        'chainid origin gasprice basefee blockhash coinbase timestamp number difficulty prevrandao gaslimit',
     literal:
         'true false'
 };

--- a/src/languages/solidity.js
+++ b/src/languages/solidity.js
@@ -237,7 +237,7 @@ function hljsDefineSolidity(hljs) {
             },
             // built-in members
             makeBuiltinProps('msg', 'gas value data sender sig'),
-            makeBuiltinProps('block', 'blockhash coinbase difficulty gaslimit basefee number timestamp chainid'),
+            makeBuiltinProps('block', 'blockhash coinbase difficulty prevrandao gaslimit basefee number timestamp chainid'),
             makeBuiltinProps('tx', 'gasprice origin'),
             makeBuiltinProps('abi', 'decode encode encodePacked encodeWithSelector encodeWithSignature encodeCall'),
             makeBuiltinProps('bytes', 'concat'),


### PR DESCRIPTION
Solidity 0.8.18 just came out, and added `block.prevrandao` as well as a `prevrandao` instruction in assembly.  This PR adds highlighting for them.

Note: 0.8.18 also addes the ability to name mapping parameters.  These should likely be highlighted?  It's not obvious to me at the moment what's a good way to do that though so I figured I'd just put up this first.